### PR TITLE
add TCP server & client (CMake targets)

### DIFF
--- a/dolsoe/CMakeLists.txt
+++ b/dolsoe/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(dolsoe LANGUAGES CXX)
+
+# 공통 설정
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# 기본 빌드 타입 (미지정 시 Release)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+
+# 공통 경고 플래그
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# 하위 디렉터리 추가
+add_subdirectory(server)
+add_subdirectory(client)

--- a/dolsoe/build.sh
+++ b/dolsoe/build.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# build — one-shot CMake build runner
+# 사용법:
+#   ./build            # 기본(Debug) 빌드
+#   ./build r          # Release 빌드
+#   ./build clean      # 클린 후 빌드
+#   ./build target X   # 특정 타겟만 빌드(X 자리에 타겟명)
+
+set -euo pipefail
+
+BUILD_DIR="build"
+BUILD_TYPE="Debug"
+TARGET=""
+DO_CLEAN=0
+
+# 간단 인자 파싱
+case "${1-}" in
+  r|release|Release) BUILD_TYPE="Release";;
+  clean) DO_CLEAN=1;;
+  target) TARGET="${2-}";;
+  "" ) ;;
+  *) echo "Unknown arg: $1"; echo "Usage: ./build [r|clean|target <name>]"; exit 1;;
+esac
+
+# clean 옵션이면 빌드 폴더 비우기
+if [[ $DO_CLEAN -eq 1 ]]; then
+  echo "[clean] removing $BUILD_DIR"
+  rm -rf "$BUILD_DIR"
+fi
+
+# configure 필요 여부 판단(CMakeCache 유무)
+if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]; then
+  echo "[configure] CMAKE_BUILD_TYPE=$BUILD_TYPE -> $BUILD_DIR"
+  cmake -S . -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+else
+  echo "[configure] skipped (already configured)."
+fi
+
+# 빌드 실행(병렬)
+if [[ -n "$TARGET" ]]; then
+  echo "[build] target: $TARGET"
+  cmake --build "$BUILD_DIR" --target "$TARGET" --parallel
+else
+  echo "[build] all"
+  cmake --build "$BUILD_DIR" --parallel
+fi
+
+echo "[done] artifacts in ./$BUILD_DIR/"

--- a/dolsoe/client/CMakeLists.txt
+++ b/dolsoe/client/CMakeLists.txt
@@ -1,0 +1,23 @@
+# 클라이언트 전용 CMake
+
+find_package(Threads REQUIRED)
+
+add_executable(client
+  source/main.cpp
+  source/client.cpp
+  source/client_handlers.cpp
+)
+
+target_include_directories(client
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/header
+)
+
+target_link_libraries(client
+  PRIVATE
+    Threads::Threads
+)
+
+set_target_properties(client PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)

--- a/dolsoe/client/header/client.h
+++ b/dolsoe/client/header/client.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// 클라이언트 시작 함수
+//  - server_ip : "127.0.0.1" 같은 IPv4 문자열
+//  - port      : 서버 포트
+// 반환값: 0(정상 종료), 0 이외(에러)
+int start_client(const char* server_ip, int port);

--- a/dolsoe/client/header/client_handlers.h
+++ b/dolsoe/client/header/client_handlers.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <string>
+#include <vector>
+
+using namespace std;
+
+// 한 줄 수신본을 파싱하고 동작 수행
+void client_handle_incoming_line(const string& raw);
+
+// 필요하면 이후에 더 쪼갤 수 있음.
+// ex) void client_handle_msg(...), client_handle_echo(...);

--- a/dolsoe/client/header/client_protocol.h
+++ b/dolsoe/client/header/client_protocol.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <sys/socket.h>
+#include <cerrno>
+
+using namespace std;
+
+// ----- 유틸: 안전 송신 (부분 전송 처리) -----
+static inline bool send_all(int fd, const char* p, size_t n) {
+    size_t off = 0;
+    while (off < n) {
+        ssize_t k = ::send(fd, p + off, n - off, MSG_NOSIGNAL);
+        if (k > 0)      off += (size_t)k;
+        else if (k < 0 && errno == EINTR) continue;
+        else            return false;
+    }
+    return true;
+}
+
+// 문자열 한 줄 전송(자동 개행). 끝에 '\n'이 없으면 붙여서 보냄.
+static inline bool send_all_line(int fd, string s) {
+    if (s.empty() || s.back() != '\n') s.push_back('\n');
+    return send_all(fd, s.data(), s.size());
+}
+
+// ----- 구분자 분할: "A@B@C" -> ["A","B","C"] -----
+static inline vector<string> split_at(const string& s, char delim) {
+    vector<string> out;
+    string cur;
+    out.reserve(8);
+    for (char ch : s) {
+        if (ch == delim) { out.push_back(move(cur)); cur.clear(); }
+        else cur.push_back(ch);
+    }
+    out.push_back(move(cur));
+    return out;
+}

--- a/dolsoe/client/source/client.cpp
+++ b/dolsoe/client/source/client.cpp
@@ -1,0 +1,108 @@
+#include "client.h"
+#include "client_protocol.h"
+#include "client_handlers.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <signal.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <cstring>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace std;
+
+static atomic<bool> g_running(true);
+
+// ----- 수신 스레드: 서버 메시지 읽어 출력 -----
+// 서버로부터 오는 데이터를 누적 버퍼(acc)에 쌓고
+// '\n' 기준으로 줄 단위로 잘라서 출력.
+static void rx_thread_func(int sock) {
+    string acc; acc.reserve(4096);
+    char buf[4096];
+
+    while (g_running.load()) {
+        ssize_t n = recv(sock, buf, sizeof(buf), 0);
+        if (n > 0) {
+            acc.append(buf, buf + n);
+            // '\n' 기준으로 출력
+            for (;;) {
+                size_t pos = acc.find('\n');
+                if (pos == string::npos) break;
+                string line = acc.substr(0, pos);
+                acc.erase(0, pos + 1);
+
+                // ---- (변경) 라인 처리 호출 ----
+                client_handle_incoming_line(line);
+            }
+        } else if (n == 0) {
+            cerr << "[INFO] server closed connection\n";
+            g_running.store(false);
+            break;
+        } else {
+            if (errno == EINTR) continue;
+            perror("recv");
+            g_running.store(false);
+            break;
+        }
+    }
+}
+
+int start_client(const char* server_ip, int port) {
+    signal(SIGPIPE, SIG_IGN); // 끊긴 소켓에 send 시 프로세스 종료 방지
+
+    // 소켓 생성
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) { perror("socket"); return 1; }
+
+    // 서버 주소 설정
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port   = htons((uint16_t)port);
+    if (inet_pton(AF_INET, server_ip, &addr.sin_addr) != 1) {
+        cerr << "Invalid IP: " << server_ip << "\n";
+        close(sock);
+        return 1;
+    }
+
+    // 연결
+    if (connect(sock, (sockaddr*)&addr, sizeof(addr)) < 0) {
+        perror("connect");
+        close(sock);
+        return 1;
+    }
+    cout << "[INFO] connected to " << server_ip << ":" << port
+         << " (type 'q' + Enter to quit)\n";
+
+    // 수신 스레드 시작
+    thread rx(rx_thread_func, sock);
+
+    // 표준입력 → 서버로 전송
+    // 한 줄 입력하면 그대로 서버에 전송(자동 '\n')
+    string line;
+    while (g_running.load() && getline(cin, line)) {
+        if (line == "q" || line == "Q") {
+            g_running.store(false);
+            break;
+        }
+        if (!send_all_line(sock, line)) {
+            cerr << "[ERROR] send failed\n";
+            g_running.store(false);
+            break;
+        }
+    }
+
+    // 종료 처리
+    shutdown(sock, SHUT_RDWR); // 수신 스레드 recv()를 0으로 떨어뜨려 종료 유도
+    rx.join();
+    close(sock);
+    cout << "[INFO] client exit\n";
+    return 0;
+}

--- a/dolsoe/client/source/client_handlers.cpp
+++ b/dolsoe/client/source/client_handlers.cpp
@@ -1,0 +1,79 @@
+#include "client_handlers.h"
+#include "client_protocol.h"
+
+#include <atomic>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+// 한 줄 수신본을 파싱하고 동작 수행
+void client_handle_incoming_line(const string& raw) {
+    auto line = raw;
+    if (!line.empty() && line.back() == '\r') line.pop_back(); // CRLF
+    auto tok = split_at(line, '@');
+    if (tok.empty() || tok[0].empty()) {
+        cout << "[RECV] " << raw << "\n";
+        return;
+    }
+
+    const string& cmd = tok[0];
+
+    // ECHO@ME@..., ECHO@ALL@...
+    if (cmd == "ECHO") {
+        if (tok.size() >= 3) {
+            string payload = tok[2];
+            for (size_t i = 3; i < tok.size(); ++i) {
+                payload.push_back('@');
+                payload += tok[i];
+            }
+            cout << "[ECHO] " << tok[1] << " | " << payload << "\n";
+        } else {
+            cout << "[ECHO] " << line << "\n";
+        }
+        return;
+    }
+
+    // --------------------------------------------
+    // 아래에 Command에 따른 처리 명령 작성하면 됨
+    // --------------------------------------------
+
+    // MSG@from@seq@payload...
+    if (cmd == "MSG") {
+        if (tok.size() >= 4) {
+            const string& from = tok[1];
+            const string& seq  = tok[2];
+            string payload = tok[3];
+            for (size_t i = 4; i < tok.size(); ++i) {
+                payload.push_back('@');
+                payload += tok[i];
+            }
+            cout << "[MSG] from=" << from << " seq=" << seq << " | " << payload << "\n";
+        } else {
+            cout << "[MSG] " << line << "\n";
+        }
+        return;
+    }
+
+    // ACK@seq
+    if (cmd == "ACK") {
+        if (tok.size() >= 2) cout << "[ACK] seq=" << tok[1] << "\n";
+        else                 cout << "[ACK] " << line << "\n";
+        return;
+    }
+
+    // NACK@seq@reason
+    if (cmd == "NACK") {
+        string reason;
+        if (tok.size() >= 3) {
+            reason = tok[2];
+            for (size_t i = 3; i < tok.size(); ++i) {
+                reason.push_back('@'); reason += tok[i];
+            }
+        }
+        cout << "[NACK] seq=" << (tok.size()>=2 ? tok[1] : "?")
+                  << " reason=" << (reason.empty()? "-" : reason) << "\n";
+        return;
+    }
+}

--- a/dolsoe/client/source/main.cpp
+++ b/dolsoe/client/source/main.cpp
@@ -1,0 +1,21 @@
+#include "../header/client.h"
+#include <iostream>
+#include <string>
+
+#define DEFAULT_PORT    5000
+
+using namespace std;
+
+int main(int argc, char* argv[]) {
+    string server_ip = "127.0.0.1";  // 문자열 리터럴은 string으로 보관
+    int port = DEFAULT_PORT;
+
+    // 인자 파싱 (유연하게)
+    if (argc >= 2)
+        server_ip = argv[1];
+    if (argc >= 3)
+        port = stoi(argv[2]);
+
+    // start_client는 const char*를 받으니 c_str()로 전달
+    return start_client(server_ip.c_str(), port);
+}

--- a/dolsoe/server/CMakeLists.txt
+++ b/dolsoe/server/CMakeLists.txt
@@ -1,0 +1,28 @@
+# 서버 전용 CMake
+# 이 디렉토리에서 server 실행파일 생성
+
+# 스레드 라이브러리 필수 (pthread)
+find_package(Threads REQUIRED)
+
+add_executable(server
+  source/main.cpp
+  source/server.cpp
+  source/server_handlers.cpp
+)
+
+# 서버에서 헤더 include 경로
+target_include_directories(server
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/header
+)
+
+# 링크
+target_link_libraries(server
+  PRIVATE
+    Threads::Threads
+)
+
+# (선택) 빌드 산출물 위치를 최상위 build/bin 아래로
+set_target_properties(server PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)

--- a/dolsoe/server/header/main.h
+++ b/dolsoe/server/header/main.h
@@ -1,0 +1,6 @@
+#ifndef MAIN_H
+#define MAIN_H
+
+
+
+#endif // MAIN_H

--- a/dolsoe/server/header/server.h
+++ b/dolsoe/server/header/server.h
@@ -1,0 +1,9 @@
+#ifndef TCP_SERVER_H
+#define TCP_SERVER_H
+
+#include <iostream>
+
+int start_server(int port);
+int server_send(int client_fd, const std::string& line);
+
+#endif // TCP_SERVER_H

--- a/dolsoe/server/header/server_handlers.h
+++ b/dolsoe/server/header/server_handlers.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "session.h"
+
+#include <string>
+#include <vector>
+#include <mutex>
+#include <unordered_map>
+#include <netinet/in.h>
+
+using namespace std;
+
+// 서버 전역 상태를 한 데 모은 컨텍스트(전역 참조를 직접 쓰지 않도록)
+struct ServerContext {
+    mutex& mtx;
+    vector<ClientInfo*>& clients;
+    unordered_map<string, ClientInfo*>& id2cli;
+};
+
+void handle_echo(ServerContext& ctx, ClientInfo* self,
+                 const vector<string>& tok,
+                 const string& fullLine);
+
+// 필요해지면 점차 추가
+// void handle_register(ServerContext& ctx, ClientInfo* self, const vector<string>& tok);
+// void handle_sensor(ServerContext& ctx, ClientInfo* self, const vector<string>& tok);
+// void handle_msg(ServerContext& ctx, ClientInfo* self, const vector<string>& tok);
+// void handle_disconnect(ServerContext& ctx, ClientInfo* self);

--- a/dolsoe/server/header/server_protocol.h
+++ b/dolsoe/server/header/server_protocol.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <sys/socket.h>
+#include <cerrno>
+
+using namespace std;
+
+// 안전 송신(부분 전송 처리). 에러 시 false.
+// MSG_NOSIGNAL: 끊긴 소켓에 send할 때 SIGPIPE 방지(리눅스).
+static inline bool send_all(int fd, const char* p, size_t n) {
+    size_t off = 0;
+    while (off < n) {
+        ssize_t k = ::send(fd, p + off, n - off, MSG_NOSIGNAL);
+        if (k > 0)      off += (size_t)k;
+        else if (k < 0 && errno == EINTR) continue;
+        else            return false;
+    }
+    return true;
+}
+
+// 문자열 한 줄 전송: 끝에 '\n'이 없으면 자동 부착.
+static inline bool send_all_line(int fd, string s) {
+    if (s.empty() || s.back() != '\n') s.push_back('\n');
+    return send_all(fd, s.data(), s.size());
+}
+
+// 구분자 1글자로 토큰 분리: "A@B@C" -> ["A","B","C"]
+static inline vector<string> split_at(const string& s, char delim) {
+    vector<string> out;
+    string cur;
+    out.reserve(8);
+    for (char ch : s) {
+        if (ch == delim) { out.push_back(move(cur)); cur.clear(); }
+        else cur.push_back(ch);
+    }
+    out.push_back(move(cur));
+    return out;
+}
+
+/*
+[프로토콜 메모]
+- 라인 단위 메시지('\n' 종료), 필드는 '@' 구분
+- ECHO@ALL@text...   -> 모든 클라이언트에게 방송
+- ECHO@ME@text...    -> 나에게만 회신
+- (예시) REGISTER@<id> / SENSOR@<id>@<value> / MSG@<to>@<seq>@...
+- (예시) DISCONNECT -> BYE 회신
+*/

--- a/dolsoe/server/header/session.h
+++ b/dolsoe/server/header/session.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <string>
+#include <thread>
+#include <netinet/in.h>
+
+using namespace std;
+
+// 클라이언트 세션 정보
+struct ClientInfo {
+    int fd;                 // 소켓 FD
+    sockaddr_in addr;       // 피어 주소
+    thread th;              // 핸들 스레드
+    string id;              // REGISTER 후 설정되는 사용자 ID (미등록이면 빈 문자열)
+};

--- a/dolsoe/server/source/main.cpp
+++ b/dolsoe/server/source/main.cpp
@@ -1,0 +1,16 @@
+#include "server.h"
+#include "main.h"
+#include <iostream>
+
+#define DEFAULT_PORT    5000
+
+using namespace std;
+
+int main(int argc, char* argv[]) {
+    int port = DEFAULT_PORT;
+    if (argc == 2)
+        port = stoi(argv[1]);
+
+    // 서버를 시작하고(차단형), 에러 시 코드 반환
+    return start_server(port);
+}

--- a/dolsoe/server/source/server.cpp
+++ b/dolsoe/server/source/server.cpp
@@ -1,0 +1,295 @@
+#include "server.h"
+#include "server_protocol.h"
+#include "server_handlers.h"
+#include "session.h"
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <signal.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <iostream>
+#include <thread>
+#include <vector>
+#include <mutex>
+#include <algorithm>
+#include <unordered_map>
+
+#include <atomic>
+#include <string>
+#include <cerrno>
+
+using namespace std;
+
+#define PACKET_SIZE 4096  // 1회 recv 임시버퍼 크기
+
+// 전역 상태(동시 접근 보호)
+static mutex g_mtx;
+static vector<ClientInfo*> g_clients;                // 접속 목록
+static unordered_map<string, ClientInfo*> g_id2cli;  // id -> ClientInfo*
+
+// 전역 실행 플래그
+static atomic<bool> g_running(true);
+static atomic<int> g_listen_fd{-1};
+
+// stdin을 감시하는 컨트롤 스레드
+static void control_thread() {
+    string line;
+    while(getline(cin, line)) {
+        if(line == "q" || line == "Q") {
+            cerr << "[CTRL] quit requested\n";
+            g_running.store(false);
+            int fd = g_listen_fd.exchange(-1); // fd 읽고 즉시 -1로
+            if(fd >= 0) {
+                shutdown(fd, SHUT_RDWR);
+                close(fd);   // accept()를 깨우는 트리거
+            }
+            break;
+        }
+    }
+}
+
+// ServerHandlers에 넘길 컨텍스트 생성 헬퍼
+static ServerContext make_ctx() {
+    return ServerContext{ g_mtx, g_clients, g_id2cli };
+}
+
+// 명령 처리: 한 줄(line, '\n' 제거됨) → 파싱/응답/포워딩
+static void handle_line(ClientInfo* self, string line) {
+    if (!line.empty() && line.back() == '\r')
+        line.pop_back(); // CRLF 대응
+
+    auto tok = split_at(line, '@');
+    if (tok.empty() || tok[0].empty())
+        return;
+
+    const string& cmd = tok[0];
+
+    // 디스패치: 각 기능은 server_handlers.*에 구현
+    auto ctx = make_ctx();
+
+    // 에코 테스트
+    if(cmd == "ECHO") {
+        handle_echo(ctx, self, tok, line);
+        return;
+    }
+
+    /*
+    ***************************예시 명령처리들***************************
+    // 1) 헬스체크
+    if (cmd == "PING") {
+        (void)send_all_line(self->fd, "PONG");
+        return;
+    }
+
+    // 2) ID 등록: REGISTER@<id>
+    if (cmd == "REGISTER") {
+        if (tok.size() < 2) { (void)send_all_line(self->fd, "ERR@FORMAT"); return; }
+        const string& new_id = tok[1];
+
+        // 중복 ID가 있으면 기존 연결 제거(정책상 NACK로 바꿀 수도 있음)
+        {
+            lock_guard<mutex> lk(g_mtx);
+            auto it_old = g_id2cli.find(new_id);
+            if (it_old != g_id2cli.end() && it_old->second != self) {
+                // 기존 세션 닫기
+                close(it_old->second->fd);
+                // 목록/맵에서 제거는 해당 스레드 종료 시점에 정리됨(레퍼런스만 삭제)
+            }
+            self->id = new_id;
+            g_id2cli[new_id] = self;
+        }
+        cerr << "[REGISTER] fd=" << self->fd << " id=" << new_id << "\n";
+        (void)send_all_line(self->fd, string("ACK@REGISTER@") + new_id);
+        return;
+    }
+
+    // 3) 센서: SENSOR@<id>@<value>  (샘플 처리)
+    if (cmd == "SENSOR") {
+        if (tok.size() < 3) { (void)send_all_line(self->fd, "ERR@FORMAT"); return; }
+        const string& sid   = tok[1];
+        const string& value = tok[2];
+        cerr << "[SENSOR] id=" << sid << " value=" << value << "\n";
+        (void)send_all_line(self->fd, string("ACK@SENSOR@") + sid + "@" + value);
+        return;
+    }
+
+    // 4) 메시지 포워딩: MSG@<to_id>@<seq>@<payload...>
+    if (cmd == "MSG") {
+        if (tok.size() < 4) { (void)send_all_line(self->fd, "ERR@FORMAT"); return; }
+        const string& to_id = tok[1];
+        const string& seq   = tok[2];
+
+        // payload 재조립(토큰 3 이후 전부)
+        string payload = tok[3];
+        for (size_t i = 4; i < tok.size(); ++i) {
+            payload.push_back('@');
+            payload += tok[i];
+        }
+
+        ClientInfo* to = find_by_id(to_id);
+        if (!to) {
+            (void)send_all_line(self->fd, string("NACK@") + seq + "@client not found");
+            return;
+        }
+
+        // 대상에게: MSG@<from_id>@<seq>@<payload...>
+        const string from_id = self->id;
+        (void)send_all_line(to->fd, string("MSG@") + from_id + "@" + seq + "@" + payload);
+
+        // 보낸 쪽에 ACK
+        (void)send_all_line(self->fd, string("ACK@") + seq);
+        return;
+    }
+
+    // 5) 클라이언트가 종료 의사: DISCONNECT
+    if (cmd == "DISCONNECT") {
+        (void)send_all_line(self->fd, "BYE"); // 실제 close는 recv 루프에서 EOF 시
+        return;
+    }
+
+    // 6) 정의되지 않은 명령
+    (void)send_all_line(self->fd, string("ERR@UNKNOWN@") + cmd);
+
+    */
+}
+
+// Client 스레드 - 수신 루프 (파싱) + 명령 처리 + 종료 처리
+static void handle_client(ClientInfo* c) {
+    cout << "[CLIENT] start fd=" << c->fd << " from "
+         << inet_ntoa(c->addr.sin_addr) << ":" << ntohs(c->addr.sin_port) << endl;
+
+    string acc;                 // TCP 누적 버퍼
+    acc.reserve(4096);
+    char buf[PACKET_SIZE];
+
+    while (true) {
+        memset(buf, 0, sizeof(buf));
+        ssize_t n = recv(c->fd, buf, sizeof(buf), 0);
+        if (n > 0) {
+            acc.append(buf, buf + n);
+
+            // '\n' 단위로 라인 분리
+            for (;;) {
+                size_t pos = acc.find('\n');
+                if (pos == string::npos)
+                    break;
+                string line = acc.substr(0, pos);
+                acc.erase(0, pos + 1);
+                handle_line(c, move(line));
+            }
+        } else if (n == 0) {
+            cout << "[CLIENT] closed fd=" << c->fd << endl;
+            break;
+        } else {
+            perror("recv");
+            break;
+        }
+    }
+
+    // 소켓 닫고 전역 상태에서 제거
+    close(c->fd);
+
+    lock_guard<mutex> lk(g_mtx);
+    // id 매핑 제거
+    if (!c->id.empty()) {
+        auto it = g_id2cli.find(c->id);
+        if (it != g_id2cli.end() && it->second == c) g_id2cli.erase(it);
+    }
+    // 접속 목록에서 제거
+    auto it2 = find(g_clients.begin(), g_clients.end(), c);
+    if (it2 != g_clients.end()) g_clients.erase(it2);
+
+    delete c; // 동적 해제
+}
+
+int start_server(int port) {
+    // 끊긴 소켓 송신시 프로세스 전체 종료 방지
+    signal(SIGPIPE, SIG_IGN);
+
+    // 1) 리스닝 소켓 생성
+    int srv = socket(AF_INET, SOCK_STREAM, 0);
+    if (srv < 0) { perror("socket"); return 1; }
+
+    int yes = 1;
+    setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+
+    // 2) 바인드
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = htons((uint16_t)port);
+
+    if (bind(srv, (sockaddr*)&addr, sizeof(addr)) < 0) {
+        perror("bind");
+        close(srv);
+        return 1;
+    }
+
+    // 3) 리슨
+    if (listen(srv, 64) < 0) {
+        perror("listen");
+        close(srv);
+        return 1;
+    }
+
+    // 전역에 리스닝 FD 저장
+    g_listen_fd.store(srv);
+    // 종료(q) 입력 감시 스레드 시작
+    thread ctrl(control_thread);
+    // ctrl.detach();
+
+    cout << "[SERVER] listening on " << port
+              << " (type 'q' + Enter to quit)\n";
+
+    // 4) accept 루프: 접속마다 스레드 생성
+    // accept 루프
+    while (g_running.load()) {
+        sockaddr_in cli{}; socklen_t clen = sizeof(cli);
+        int cs = accept(srv, (sockaddr*)&cli, &clen);
+        if (cs < 0) {
+            if (!g_running.load() || errno == EBADF) break;     // 의도적 종료
+            if (errno == EINTR) continue;     // 신호 인터럽트 재시도
+            perror("accept");
+            continue;
+        }
+
+        // 세션 구조체 생성/등록
+        ClientInfo* c = new ClientInfo;
+        c->fd = cs;
+        c->addr = cli;
+
+        {
+            lock_guard<mutex> lk(g_mtx);
+            g_clients.push_back(c);
+        }
+
+        // 스레드 시작(분리)
+        c->th = thread(handle_client, c);
+        c->th.detach();
+
+        cout << "[CONNECT] " << inet_ntoa(cli.sin_addr) << ":" << ntohs(cli.sin_port)
+             << " fd=" << cs << " (alive=" << g_clients.size() << ")\n";
+    }
+
+    ctrl.join();
+
+    // FD 스냅샷만 락으로 가져오고, 시스템콜은 락 밖에서 수행
+    std::vector<int> fds_to_close;
+    {
+        std::unique_lock<std::mutex> lk(g_mtx);
+        fds_to_close.reserve(g_clients.size());
+        for (auto* c : g_clients) fds_to_close.push_back(c->fd);
+        lk.unlock();
+    }
+    for (int fd : fds_to_close) {
+        shutdown(fd, SHUT_RDWR);
+        close(fd);
+    }
+
+    // 일반적으로 도달하지 않음(종료 처리 경로 만들 경우 close(srv) 등)
+    int fd = g_listen_fd.exchange(-1);
+    if (fd >= 0) close(fd);
+    return 0;
+}

--- a/dolsoe/server/source/server_handlers.cpp
+++ b/dolsoe/server/source/server_handlers.cpp
@@ -1,0 +1,41 @@
+#include "server_handlers.h"
+#include "server_protocol.h"   // send_all_line, split_at 등
+
+#include <algorithm>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <errno.h>
+#include <thread>
+
+using namespace std;
+
+static vector<int> snapshot_client_fds(ServerContext& ctx) {
+    vector<int> fds;
+    lock_guard<mutex> lk(ctx.mtx);
+    fds.reserve(ctx.clients.size());
+    for (auto* c : ctx.clients) fds.push_back(c->fd);
+    return fds;
+}
+
+static ClientInfo* find_by_id(ServerContext& ctx, const string& id) {
+    lock_guard<mutex> lk(ctx.mtx);
+    auto it = ctx.id2cli.find(id);
+    return (it == ctx.id2cli.end()) ? nullptr : it->second;
+}
+
+void handle_echo(ServerContext& ctx, ClientInfo* self,
+                 const vector<string>& tok,
+                 const string& fullLine)
+{
+    if (tok.size() < 2) { (void)send_all_line(self->fd, "ERR@FORMAT"); return; }
+    const string& who = tok[1];
+
+    if (who == "ALL") {
+        auto fds = snapshot_client_fds(ctx);
+        for (int fd : fds) (void)send_all_line(fd, fullLine);
+    } else if (who == "ME") {
+        (void)send_all_line(self->fd, fullLine);
+    } else {
+        (void)send_all_line(self->fd, "ERR@UNKNOWN@ECHO_TARGET");
+    }
+}


### PR DESCRIPTION
- server : port인자를 받아 listen, Client 별 thread 처리
- client : IP/port argument, stdin 전송/응답 출력
- commonness : 기본값, 에러 처리, 로그 최소화
- build : CMake Target server, client 추가 실행 예시) ./server <port> / ./client <ip> <port>
ip, port 생략 시 기본값 (127.0.0.1), (5000)

CMake 실행 스크립트 : ./dolsoe/build.sh